### PR TITLE
Fix extraneous tags in index page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,5 +65,3 @@ import { config } from '../data/config';
   });
 </script>
 
-</file>
-</boltArtifact>


### PR DESCRIPTION
## Summary
- remove stray `</file>` and `</boltArtifact>` tags from `index.astro`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f668b379883279007489a93939328